### PR TITLE
Script improvements including skip updates for past dates

### DIFF
--- a/schedulesync.gs
+++ b/schedulesync.gs
@@ -135,7 +135,12 @@ function scheduleSync(programs, updatePastDates = false) {
 
     // skip calendar updates if there are no results
     // Note: this may result in cancelled events not being removed from the calendar
-    if (programSchedule.length === 0) continue;
+    if (programSchedule.length === 0) {
+      Logger.log(
+        `No matching events found for location ID ${locationID} with title "${courseTitle}"${userAge ? ` and user age of ${userAge}` : ""}`
+      );
+      continue;
+    }
 
     const programEvents = programSchedule.map((x) => convertEntryToEvent(x, locations));
 
@@ -153,7 +158,9 @@ function scheduleSync(programs, updatePastDates = false) {
     deleteExistingEvents(firstDate, lastDate, eventTitles, eventLocation, calendarID);
 
     // add new calendar events within timeframe
-    Logger.log(`Adding or updating ${programEvents.length} events...`);
+    Logger.log(
+      `Adding or updating ${programEvents.length} events at ${eventLocation} between ${firstDate} and ${lastDate} with titles ${eventTitles.map((x) => `"${x}"`).join("; ")}...`
+    );
     for (const event of programEvents) {
       createEvent(event, calendarID, color);
     }
@@ -269,7 +276,9 @@ function deleteExistingEvents(
   const inputCalendar = CalendarApp.getCalendarById(calendarID);
   const existingEvents = inputCalendar.getEvents(firstDate, lastDate);
 
-  Logger.log(`Deleting existing events...`);
+  Logger.log(
+    `Deleting ${existingEvents.length} existing events at ${eventLocation} between ${firstDate} and ${lastDate} with titles ${eventTitles.map((x) => `"${x}"`).join("; ")} ...`
+  );
   for (let existingEvent of existingEvents) {
     if (
       eventTitles.includes(existingEvent.getTitle()) &&

--- a/schedulesync.gs
+++ b/schedulesync.gs
@@ -145,13 +145,14 @@ function scheduleSync(programs, updatePastDates = false) {
     const programEvents = programSchedule.map((x) => convertEntryToEvent(x, locations));
 
     // delete current calendar events within result timeframe
+    // + Time offsets added due to known quirk of Date constructor - needed to ensure ISO date is interpreted in user's timezone and to represent end or start of day
     const firstDate = updatePastDates
       ? programSchedule
-          .map((e) => new Date(e["First Date"]))
+          .map((e) => new Date(e["First Date"] + "T00:00:00"))
           .reduce((p, c) => (c < p ? c : p))
       : todayStart;
     const lastDate = programSchedule
-      .map((e) => new Date(e["Last Date"]))
+      .map((e) => new Date(e["Last Date"] + "T23:59:59"))
       .reduce((p, c) => (c > p ? c : p));
     const eventTitles = [...new Set(programEvents.map((e) => e.title))];
     const eventLocation = programEvents[0]["options"]["location"];


### PR DESCRIPTION
Small improvements to the script:

- skips updates to past dates by default, which helps to reduce run time and allow for more schedules to be updated
- made log messages more informative
- fixed bug with quirk of `Date` constructor